### PR TITLE
Ignore status codes in drop handlers (closes #5)

### DIFF
--- a/src/connector.rs
+++ b/src/connector.rs
@@ -137,13 +137,7 @@ impl Connector {
 impl Drop for Connector {
     fn drop(&mut self) {
         if self.connected.get() {
-            unsafe {
-                let rc = ReturnCode::from(yubihsm_sys::yh_disconnect(self.this.get()));
-
-                if rc != ReturnCode::Success {
-                    panic!("failed to disconnect session: {}", rc);
-                }
-            }
+            unsafe { yubihsm_sys::yh_disconnect(self.this.get()); }
         }
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -318,17 +318,8 @@ impl Session {
 impl Drop for Session {
     fn drop(&mut self) {
         unsafe {
-            let rc = ReturnCode::from(yubihsm_sys::yh_util_close_session(self.this.get()));
-
-            if rc != ReturnCode::Success {
-                panic!("failed to close session: {}", rc);
-            }
-
-            let rc = ReturnCode::from(yubihsm_sys::yh_destroy_session(&mut self.this.get()));
-
-            if rc != ReturnCode::Success {
-                panic!("failed to destroy session: {}", rc);
-            }
+            yubihsm_sys::yh_util_close_session(self.this.get());
+            yubihsm_sys::yh_destroy_session(&mut self.this.get());
         }
     }
 }


### PR DESCRIPTION
This was causing spurious panics: we don't care about errors closing sessions or disconnecting inside of drop handlers.